### PR TITLE
Correctly detect session expiry on Donor Deceased

### DIFF
--- a/src/App/src/Action/DonorDeceasedAction.php
+++ b/src/App/src/Action/DonorDeceasedAction.php
@@ -13,6 +13,12 @@ class DonorDeceasedAction extends AbstractAction
 
     public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
+        if (!$this->isActionAccessible($request)) {
+            return new Response\RedirectResponse($this->getUrlHelper()->generate('session'));
+        }
+
+        //---
+
         $session = $request->getAttribute('session');
 
         $form = new Form\DonorDeceased([


### PR DESCRIPTION
Ensure the correct error message is returned on session expiry whilst on the Donor Deceased page.