### PR TITLE
Strip out quote marks from submitted fields

### DIFF
--- a/src/App/src/Service/Refund/ProcessApplication.php
+++ b/src/App/src/Service/Refund/ProcessApplication.php
@@ -40,6 +40,13 @@ class ProcessApplication implements Initializer\LogSupportInterface
 
         //---
 
+        // Tidy up data - strip out quote marks
+        array_walk_recursive($data, function(&$item, $key){
+            $item = str_replace('"', '', $item);
+        });
+
+        //---
+
         // Include the date submitted
         $data['version'] = 1;
 

--- a/src/App/src/Service/Refund/ProcessApplication.php
+++ b/src/App/src/Service/Refund/ProcessApplication.php
@@ -42,7 +42,7 @@ class ProcessApplication implements Initializer\LogSupportInterface
 
         // Tidy up data - strip out quote marks
         array_walk_recursive($data, function(&$item, $key){
-            $item = str_replace('"', '', $item);
+            $item = (is_string($item)) ? str_replace('"', '', $item) : $item;
         });
 
         //---

--- a/src/App/src/Service/Refund/ProcessApplication.php
+++ b/src/App/src/Service/Refund/ProcessApplication.php
@@ -61,7 +61,6 @@ class ProcessApplication implements Initializer\LogSupportInterface
 
         if ($validator->fails()) {
             $errors = $validator->errors();
-            $this->getLogger()->alert('Invalid JSON generated', [ 'errors' => $errors ]);
             throw new \UnexpectedValueException('Invalid JSON generated: ' . print_r($errors, true));
         }
 


### PR DESCRIPTION
And stop duplicate errors being triggered from JSON validation fails.